### PR TITLE
Updated webviewer to v11

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,2 +1,2 @@
-Copyright 2019 PDFTron Systems Inc. All rights reserved.
-WebViewer React UI project/codebase or any derived works is only permitted in solutions with an active commercial PDFTron WebViewer license. For exact licensing terms please refer to your commercial WebViewer license. For use in other scenario, please contact sales@pdftron.com
+Copyright 2024 Apryse Systems Inc. All rights reserved.
+WebViewer UI project/codebase or any derived works is only permitted in solutions with an active commercial Apryse WebViewer license. For exact licensing terms refer to the commercial WebViewer license. For licensing, pricing, or product questions, Contact [Sales](https://apryse.com/form/contact-sales).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TypeScript PDF Viewer Sample (WebViewer)
 
-[WebViewer](https://www.pdftron.com/documentation/web/) is a powerful JavaScript-based PDF Library that's part of the [PDFTron PDF SDK](https://www.pdftron.com). It provides a slick out-of-the-box responsive UI that interacts with the core library to view, annotate and manipulate PDFs that can be embedded into any web project.
+[WebViewer](https://docs.apryse.com/documentation/web/) is a powerful JavaScript-based PDF Library that is part of the [Apryse SDK](https://apryse.com/). It provides a slick out-of-the-box responsive UI that interacts with the core library to view, annotate and manipulate PDFs that can be embedded into web projects.
 
 ![WebViewer UI](https://www.pdftron.com/downloads/pl/webviewer-ui.png)
 
@@ -28,7 +28,7 @@ Follow the steps below to set the license key in this sample:
 ## Install
 
 ```shell
-git clone https://github.com/PDFTron/webviewer-typescript-sample.git
+git clone https://github.com/ApryseSDK/webviewer-typescript-sample.git
 cd webviewer-typescript-sample
 npm install
 ```
@@ -49,7 +49,7 @@ npm start
 
 ## WebViewer APIs
 
-Most classes and functions are well documented in the TypeScript definition file. See [API documentation](https://www.pdftron.com/documentation/web/guides/ui/apis).
+Most classes and functions are well documented in the TypeScript definition file. See [API documentation](https://docs.apryse.com/documentation/web/guides/full-api/).
 
 ## Enabling full API
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ npm start
 
 ## WebViewer APIs
 
-Most classes and functions are well documented in the TypeScript definition file. See [API documentation](https://docs.apryse.com/documentation/web/guides/full-api/).
+Most classes and functions are well documented in the TypeScript definition file. See [API documentation](https://docs.apryse.com/api/web/WebViewerInstance.html).
 
 ## Enabling full API
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@pdftron/webviewer": "^10.0.0",
+    "@pdftron/webviewer": "^11.0.0",
     "typescript": "^2.1.6"
   },
   "devDependencies": {


### PR DESCRIPTION
Updated webviewer version to v11 in package.json.
Builds and runs successfully but there are package vulnerabilities and errors when running `npm run watch`.
Reported in this Jira ticket: https://apryse.atlassian.net/browse/WVR-7247